### PR TITLE
3 fixes to lecture 1.1

### DIFF
--- a/Module_1/Lecture_1/Intro_to_Audio_ML.ipynb
+++ b/Module_1/Lecture_1/Intro_to_Audio_ML.ipynb
@@ -285,9 +285,9 @@
    "outputs": [],
    "source": [
     "# # Uncomment it to download\n",
-    "# !kaggle datasets download -d mfekadu/english-multispeaker-corpus-for-voice-cloning\n",
-    "# mkdir ../../data/VCTK\n",
-    "# !unzip english-multispeaker-corpus-for-voice-cloning.zip -d ../../data/VCTK/"
+    "# !kaggle datasets download -d mfekadu/english-multispeaker-corpus-for-voice-cloning --path ../../data/\n",
+    "# !mkdir ../../data/VCTK\n",
+    "# !unzip -q ../../data/english-multispeaker-corpus-for-voice-cloning.zip -d ../../data/VCTK/"
    ]
   },
   {
@@ -415,7 +415,8 @@
     "    \"../../data/VCTK/VCTK-Corpus/VCTK-Corpus/wav48/*/*.wav\", recursive=True\n",
     ")\n",
     "# In case of Windows\n",
-    "wave_pathes = [wave_path.replace('\\\\', '/') for wave_path in wave_pathes]"
+    "if os.name == 'nt':\n",
+    "    wave_pathes = [wave_path.replace('\\\\', '/') for wave_path in wave_pathes]"
    ]
   },
   {
@@ -1400,7 +1401,7 @@
    "outputs": [],
    "source": [
     "sample_audio_or_2_22050 = librosa.resample(sample_audio_or, orig_sr=sample_audio_sr_or, target_sr=22050)\n",
-    "sample_audio_or_2_22050_2_or = librosa.resample(sample_audio_or, orig_sr=22050, target_sr=sample_audio_sr_or)"
+    "sample_audio_or_2_22050_2_or = librosa.resample(sample_audio_or_2_22050, orig_sr=22050, target_sr=sample_audio_sr_or)"
    ]
   },
   {


### PR DESCRIPTION
In this pull requests there are 3 minor fixes:
1. add path to kaggle dataset download, add ! before mkdir and -q option for unzip
```sh
!kaggle datasets download -d mfekadu/english-multispeaker-corpus-for-voice-cloning --path ../../data/
!mkdir ../../data/VCTK
!unzip -q ../../data/english-multispeaker-corpus-for-voice-cloning.zip -d ../../data/VCTK/
```
2. add `if os.name == 'nt'` in case of Windows
3. use correct sample audio in resampling example. In `sample_audio_or_2_22050_2_or` was used `sample_audio_or` but not `sample_audio_or_2_22050`. Refined code looks like this:

```python
sample_audio_or_2_22050 = librosa.resample(sample_audio_or, orig_sr=sample_audio_sr_or, target_sr=22050)
sample_audio_or_2_22050_2_or = librosa.resample(sample_audio_or_2_22050, orig_sr=22050, target_sr=sample_audio_sr_or)
```